### PR TITLE
Honor LAUNCHPAD_BROWSERS when defining default browsers

### DIFF
--- a/run-wct.js
+++ b/run-wct.js
@@ -3,11 +3,22 @@
 const gulp = require('gulp');
 const wct = require('web-component-tester/runner/test');
 
+function getDefaultBrowsers() {
+	if (process.env.LAUNCHPAD_BROWSERS) {
+		// The user tried to restrict the browsers that launchpad automatically detects,
+		// follow that: return no default browsers, and let wct pick the ones from launchpad.
+		return [];
+	}
+
+	// Assume these two are available and should be used.
+	return ['chrome', 'firefox'];
+}
+
 /**
  * Runs the tests in Web Component Tester
- * 
+ *
  * @param {Object} args Command line argument for tests
- * 
+ *
  * NB: This is a copy of the wct:local task from web-component-tester, with additional logic to override some configuration settings.
  */
 exports.runWct = function runWct({ suite, browser, debug } = args) {
@@ -34,13 +45,13 @@ exports.runWct = function runWct({ suite, browser, debug } = args) {
 
 /**
  * Adds command line arguments for the tests
- * 
+ *
  * @param {Object} yargs Yargs instance
  */
 exports.addYargs = function addWctYargs(yargs) {
 	return yargs.option('browser', {
 		describe: 'Browsers on which tests should run',
-		default: ['chrome', 'firefox'],
+		default: getDefaultBrowsers(),
 		type: 'array',
 	})
 	.option('debug', {


### PR DESCRIPTION
When one typically wants to limit the browsers supported by wct one can set the `LAUNCHPAD_BROWSERS` environment variable to do so.

This breaks with the gulp-polymer-build-utils, because it requires the browsers via the `--browser` argument, or assumes "chrome" and "firefox". The message from launchpad is then rather confusing:
~~~~
[09:40:24] Error: The following browsers are unsupported: firefox. (All supported browsers: chrome)
~~~~

Fix this by not setting a default browser list when `LAUNCHPAD_BROWSERS` is defined, so that the wct autodetection is used in those cases.